### PR TITLE
Added Checks for UTC time

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -98,7 +98,6 @@ class My_Client:
             # check the timestamp
             try:
                 self.check_timestamp(sensor_timestamp)
-                self.is_packet_time_utc(sensor_timestamp)
             except ValueError as e:
                 logging.error(f"[MQTT CLIENT] {e}")
                 return
@@ -285,13 +284,15 @@ class My_Client:
 
         try:
             # Try to parse the timestamp
-            parsed_time = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
         except ValueError as e:
             raise ValueError(f"Invalid ISO-8601 timestamp format: {timestamp}") from e
 
         # Check that it is in UTC
-        if parsed_time.tzinfo is None or parsed_time.tzinfo.utcoffset(parsed_time) != timedelta(0):
-            raise ValueError(f"Timestamp is not in UTC timezone: {timestamp}")
+        try:
+            self.is_packet_time_utc(timestamp)
+        except ValueError as e:
+            raise ValueError(f"{e}")
     
     @staticmethod
     def is_packet_time_utc(packet_naive_dt, tolerance_minutes=30):
@@ -299,6 +300,9 @@ class My_Client:
         Determines whether the given packet time is in UTC by comparing to system UTC time.
         Assumes `packet_naive_dt` is a naive datetime object (no tzinfo).
         """
+        # Parse the ISO 8601 timestamp string
+        packet_naive_dt = datetime.fromisoformat(packet_naive_dt)
+
         # Get the current UTC time based on the system clock
         now_utc = datetime.now(timezone.utc)
         

--- a/app/client.py
+++ b/app/client.py
@@ -312,7 +312,7 @@ class My_Client:
 
         # If difference is small (e.g., < 5 minutes), assume packet was in UTC
         if delta_seconds > (tolerance_minutes * 60):
-            raise ValueError(f"Packet time is not in UTC. Difference: {delta_seconds} seconds")
+            raise ValueError(f"ERROR, Packet time is not in UTC. Difference: {delta_seconds} seconds")
 
     def run(self):
         logging.info(f"[MQTT CLIENT] connecting [{self.args.mqtt_server_ip}:{self.args.mqtt_server_port}]...")

--- a/app/decoder.py
+++ b/app/decoder.py
@@ -40,7 +40,7 @@ class Decoder: # This class is used to decode the data received from the sensor
         dt = datetime.strptime(date+'-'+time,'%d-%m-%Y-%H:%M:%S')
         logging.debug(f"[DECODER] Timestamp local?: {dt}")
         dt = dt.replace(tzinfo=timezone.utc) # UTC
-        logging.debug(f"[DECODER] Timestamp UTC: {timestamp}")
+        logging.debug(f"[DECODER] Timestamp UTC: {dt}")
         timestamp = dt.isoformat(timespec='seconds')
         logging.debug(f"[DECODER] Timestamp UTC seconds: {timestamp}")
    

--- a/app/decoder.py
+++ b/app/decoder.py
@@ -7,7 +7,18 @@ import pandas as pd
 import crcmod
 import os
 import logging
+from typing import Tuple, List, TypedDict
 from zoneinfo import ZoneInfo
+
+# Define types for the payload and timestamp
+Timestamp = str
+
+class Measurement(TypedDict):
+    name: str
+    value: float
+
+class Payload(TypedDict):
+    measurements: List[Measurement]
 
 class Decoder: # This class is used to decode the data received from the sensor
 
@@ -16,7 +27,7 @@ class Decoder: # This class is used to decode the data received from the sensor
         self.sensor_timezone = 'America/Chicago'
         self.sensor_time_is_utc = False
 
-    def decode(self, payload):
+    def decode(self, payload: bytes) -> Tuple[Payload, Timestamp]:
         # Decode the payload and return a dictionary with the decoded values in this structure:
         # payload = {
         #   measurements:[

--- a/app/decoder.py
+++ b/app/decoder.py
@@ -11,9 +11,10 @@ from zoneinfo import ZoneInfo
 
 class Decoder: # This class is used to decode the data received from the sensor
 
-    def __init__(self, sensor_timezone='America/Chicago', sensor_time_is_utc=False): # Set your data/timezone here
-        self.sensor_timezone = sensor_timezone
-        self.sensor_time_is_utc = sensor_time_is_utc
+    def __init__(self): 
+        # Set your data/timezone here
+        self.sensor_timezone = 'America/Chicago'
+        self.sensor_time_is_utc = False
 
     def decode(self, payload):
         # Decode the payload and return a dictionary with the decoded values in this structure:
@@ -52,7 +53,7 @@ class Decoder: # This class is used to decode the data received from the sensor
             logging.debug("[DECODER] Packet time appears to be local; converting to UTC.")
             local_zone = ZoneInfo(self.sensor_timezone)
             dt = dt_naive.replace(tzinfo=local_zone).astimezone(timezone.utc)
-        logging.debug(f"[DECODER] Packet time: {dt_naive} (local) -> {dt} (UTC)")
+            logging.debug(f"[DECODER] Packet time: {dt_naive} ({self.sensor_timezone}) -> {dt} (UTC)")
         timestamp = dt.isoformat(timespec='seconds')
    
         # Build dictionary of parameters

--- a/app/decoder.py
+++ b/app/decoder.py
@@ -38,8 +38,11 @@ class Decoder: # This class is used to decode the data received from the sensor
         
         # Get measurement timestamp ISO-8601
         dt = datetime.strptime(date+'-'+time,'%d-%m-%Y-%H:%M:%S')
+        logging.debug(f"[DECODER] Timestamp local?: {dt}")
         dt = dt.replace(tzinfo=timezone.utc) # UTC
+        logging.debug(f"[DECODER] Timestamp UTC: {timestamp}")
         timestamp = dt.isoformat(timespec='seconds')
+        logging.debug(f"[DECODER] Timestamp UTC seconds: {timestamp}")
    
         # Build dictionary of parameters
         measurements = [{"name": "device_id", "value": device_id, "unit": ""}, 


### PR DESCRIPTION
This pull request introduces enhancements to timestamp handling and decoding logic, focusing on improving the accuracy of timezone detection and ensuring timestamps are correctly interpreted as UTC or local time. It also includes type annotations and new utility methods for better code clarity and maintainability.

### Timestamp handling improvements:

* Updated `check_timestamp` in `app/client.py` to delegate UTC validation to a new `is_packet_time_utc` method, which compares the packet timestamp with the system's UTC time to determine if it is in UTC. This ensures more robust timezone validation.
* Added the `is_packet_time_utc` static method to `app/client.py`, which calculates the time difference between the packet timestamp and the system UTC time to validate whether the timestamp is in UTC, with a configurable tolerance.

### Decoding logic enhancements:

* Enhanced the `decode` method in `app/decoder.py` to handle both UTC and local timestamps. It assigns the appropriate timezone (UTC or local) based on the `is_packet_time_utc` check or a new `sensor_time_is_utc` flag, ensuring accurate timezone conversion.
* Added a `sensor_timezone` attribute and a `sensor_time_is_utc` flag to the `Decoder` class, allowing configuration of the sensor's timezone and whether its timestamps are already in UTC.

### Code maintainability improvements:

* Introduced type annotations and `TypedDict` definitions (`Measurement` and `Payload`) in `app/decoder.py` to clarify the structure of decoded data and improve type safety.
* Added a new `is_packet_time_utc` static method to `app/decoder.py`, similar to the one in `app/client.py`, to determine if a packet timestamp is in UTC based on the system clock. This avoids duplication of logic across files.