### PR TITLE
Fixed Subscribe issue

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -49,7 +49,7 @@ class My_Client:
                     topic = (f"application/+/device/{dev_eui}/#", qos)
                     topics.append(topic)
             else:
-                logging.info(f"[MQTT CLIENT] No dev_eui provided, subscribing to {self.args.mqtt_subscribe_topic}")
+                logging.info(f"[MQTT CLIENT] No Device EUI(s) provided, subscribing to {self.args.mqtt_subscribe_topic}")
                 logging.warning(f"[MQTT CLIENT] WARNING! Subscribing to all devices may cause issues if Decoder class is not able to decode all devices.")
                 topic = (f"{self.args.mqtt_subscribe_topic}", qos)
                 topics.append(topic)

--- a/app/client.py
+++ b/app/client.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime
 import paho.mqtt.client as mqtt
 from waggle.plugin import Plugin
 from parse import *
@@ -40,7 +40,22 @@ class My_Client:
     def on_connect(self, client, userdata, flags, rc):
         if rc == 0:
             logging.info("[MQTT CLIENT] Connected to MQTT broker")
-            client.subscribe(self.args.mqtt_subscribe_topic)
+
+            # topics
+            topics = []
+            qos = 0 # Quality of Service
+            if self.args.dev_eui:
+                for dev_eui in self.args.dev_eui:
+                    topic = (f"application/+/device/{dev_eui}/#", qos)
+                    topics.append(topic)
+            else:
+                logging.info(f"[MQTT CLIENT] No dev_eui provided, subscribing to {self.args.mqtt_subscribe_topic}")
+                logging.warning(f"[MQTT CLIENT] WARNING! Subscribing to all devices may cause issues if Decoder class is not able to decode all devices.")
+                topic = (f"{self.args.mqtt_subscribe_topic}", qos)
+                topics.append(topic)
+
+            # subscribe to topics
+            client.subscribe(topics)
         else:
             logging.error(f"[MQTT CLIENT] Connection to MQTT broker failed with code {rc}") 
         return
@@ -52,7 +67,7 @@ class My_Client:
 
     @staticmethod
     def on_log(client, obj, level, string):
-        logging.debug(f"[MQTT CLIENT] on_log: {string}") #prints if args.debug = true
+        logging.debug(f"[MQTT CLIENT]: {string}") #prints if args.debug = true
         return
 
     def publish_message(self, client, userdata, message):

--- a/app/decoder.py
+++ b/app/decoder.py
@@ -7,7 +7,7 @@ import pandas as pd
 import crcmod
 import os
 import logging
-from typing import Tuple, List, TypedDict
+from typing import Tuple, List, TypedDict, Union
 from zoneinfo import ZoneInfo
 
 # Define types for the payload and timestamp
@@ -15,7 +15,8 @@ Timestamp_utc_iso8601 = str
 
 class Measurement(TypedDict):
     name: str
-    value: float
+    value: Union[float, int, str]
+    unit: str
 
 class Payload(TypedDict):
     measurements: List[Measurement]
@@ -31,8 +32,8 @@ class Decoder: # This class is used to decode the data received from the sensor
         # Decode the payload and return a dictionary with the decoded values in this structure:
         # payload = {
         #   measurements:[
-        #   {name:"<measurement name>",value:<measurement value>},
-        #   {name:"<measurement name>",value:<measurement value>}, ...
+        #   {name:"<measurement name>",value:<measurement value>, unit:"<measurement unit>"}, ...
+        #   {name:"<measurement name>",value:<measurement value>, unit:"<measurement unit>"}, ...
         #   ]
         # }
         # This is a placeholder function. The actual decoding logic should be implemented here.

--- a/app/main.py
+++ b/app/main.py
@@ -79,7 +79,7 @@ def main():
     )
 
     #check if dev_eui is empty
-    if args.dev_eui:
+    if args.dev_eui == []:
         logging.error("[MAIN] Argument --dev_eui was not provided, no packets can be retrieved. Set the argument, to configure which devices to subcribe to. see --help or plugin documentation, Exiting...")
         exit(1)
 

--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,13 @@ def main():
         help="Pass flag to NOT publish raw payload to beehive",
         type=bool
     )
+    parser.add_argument(
+        "--dev_eui",
+        nargs="*",  # 0 or more values expected => creates a list
+        type=str,
+        default=[],
+        help="Device EUI(s) to retrieve packets from. If empty none will be retrieved (ex: --dev_eui 1234567890abcdef 5554567691abcdef). They MUST be registered in Network server!",
+    )
     
     #get args
     args = parser.parse_args()
@@ -70,6 +77,11 @@ def main():
         format="%(asctime)s %(message)s",
         datefmt="%Y/%m/%d %H:%M:%S",
     )
+
+    #check if dev_eui is empty
+    if args.dev_eui:
+        logging.error("[MAIN] Argument --dev_eui was not provided, no packets can be retrieved. Set the argument, to configure which devices to subcribe to. see --help or plugin documentation, Exiting...")
+        exit(1)
 
     #configure client
     mqtt_client = My_Client(args)


### PR DESCRIPTION
This pull request introduces enhancements to the MQTT client subscription logic, improves type definitions in the decoder, and adds a new command-line argument for specifying device EUIs. The changes aim to improve flexibility, robustness, and clarity in the codebase.

### MQTT Client Enhancements:
* Updated the MQTT subscription logic to allow subscribing to specific device EUIs if provided, or to a default topic otherwise. Added logging to warn about potential issues when subscribing to all devices. (`app/client.py`)
* Adjusted the log format in the `on_log` method for consistency. (`app/client.py`)

### Decoder Improvements:
* Extended the `Measurement` type to support `float`, `int`, and `str` for the `value` field and added a new `unit` field to include measurement units. (`app/decoder.py`)
* Updated the placeholder decoding logic comments to reflect the new structure of the `Measurement` type. (`app/decoder.py`)

### Command-line Argument Addition:
* Added a `--dev_eui` argument to allow users to specify device EUIs for MQTT subscription. If no EUIs are provided, the program exits with an error message. (`app/main.py`) [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR63-R69) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR81-R85)